### PR TITLE
dynamic-wallpaper: add shuffle_* folder support

### DIFF
--- a/home/services/wayland/dynamic-wallpaper.nix
+++ b/home/services/wayland/dynamic-wallpaper.nix
@@ -3,7 +3,7 @@
   isLaptop,
   ...
 }: let
-  groupLinx = "AnimeCity";
+  groupLinx = "shuffle_Anime";
   groupNixus = "Fuji";
 in {
   services.swww.enable = true;
@@ -21,6 +21,12 @@ in {
       then groupLinx
       else groupNixus;
     currentLink = config.home.homeDirectory + "/.cache/dynamic-wallpaper/current";
+
+    # shuffleMode/image are only used for groups named with `shuffle_` prefix.
+    # - random: pick a random image from the folder each refresh.
+    # - fixed: pin one file (set image to file stem, filename, or full path).
+    shuffleMode = "random";
+    # image = "wallpaper-01";
 
     # NOTE: Available groups:
     # - 'Alps' - 19 images - 5120x2880 - avg #7C8DB6 - ~60% bright

--- a/modules/dynamic-wallpaper/default.nix
+++ b/modules/dynamic-wallpaper/default.nix
@@ -48,6 +48,18 @@ in {
       description = "End time of the wallpaper cycle (HH:MM).";
     };
 
+    shuffleMode = mkOption {
+      type = types.enum ["random" "fixed"];
+      default = "random";
+      description = "Behavior for groups prefixed with shuffle_.";
+    };
+
+    image = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Image to use when shuffleMode is fixed (filename, stem, or path).";
+    };
+
     refreshInterval = mkOption {
       type = types.str;
       default = "30m";
@@ -75,7 +87,11 @@ in {
         DYNAMIC_WALLPAPER_LINK = cfg.currentLink;
         DYNAMIC_WALLPAPER_START = cfg.startTime;
         DYNAMIC_WALLPAPER_END = cfg.endTime;
+        DYNAMIC_WALLPAPER_SHUFFLE_MODE = cfg.shuffleMode;
         DYNAMIC_WALLPAPERS_ROOT = "${config.home.homeDirectory}/.dotfiles/lib/wallpapers";
+      }
+      // optionalAttrs (cfg.image != null) {
+        DYNAMIC_WALLPAPER_IMAGE = cfg.image;
       }
       // (
         if cfg.directory != null
@@ -103,6 +119,9 @@ in {
           "DYNAMIC_WALLPAPER_LINK=${cfg.currentLink}"
           "DYNAMIC_WALLPAPER_START=${cfg.startTime}"
           "DYNAMIC_WALLPAPER_END=${cfg.endTime}"
+          "DYNAMIC_WALLPAPER_SHUFFLE_MODE=${cfg.shuffleMode}"
+        ] ++ lib.optionals (cfg.image != null) [
+          "DYNAMIC_WALLPAPER_IMAGE=${cfg.image}"
         ];
       };
     };

--- a/pkgs/dynamic-wallpaper/completions/_dynamic_wallpaper
+++ b/pkgs/dynamic-wallpaper/completions/_dynamic_wallpaper
@@ -5,11 +5,14 @@ local -a times
 
 _arguments \
   '(-d --dir)'{-d,--dir}'[Directory containing wallpapers]:directory:_files -/' \
+  '(-g --group)'{-g,--group}'[Wallpaper group]:group:_files' \
   '--light[Always use the lightest wallpaper]' \
   '--auto-light[Use the lightest wallpaper when GNOME is in light mode]' \
   '--start[Start time for the cycle]:time:(${times})' \
   '--end[End time for the cycle]:time:(${times})' \
   '--time[Use fake current time]:time:(${times})' \
+  '--shuffle-mode[Shuffle behavior for shuffle_ groups]:mode:(random fixed)' \
+  '--image[Image when shuffle-mode is fixed]:image:_files' \
   '(-l --log)'{-l,--log}'[Write log output to FILE]:file:_files' \
   '(-h --help)'{-h,--help}'[Show help]' \
   '*:file:_files'

--- a/pkgs/dynamic-wallpaper/completions/dynamic-wallpaper.bash
+++ b/pkgs/dynamic-wallpaper/completions/dynamic-wallpaper.bash
@@ -5,11 +5,23 @@ _dynamic_wallpaper() {
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD - 1]}"
-  opts="-d --dir --light --auto-light --start --end --time -l --log -h --help"
+  opts="-d --dir -g --group --light --auto-light --start --end --time --shuffle-mode --image -l --log -h --help"
 
   case "$prev" in
   -d | --dir)
     mapfile -t COMPREPLY < <(compgen -o dirnames -- "$cur")
+    return 0
+    ;;
+  -g | --group)
+    mapfile -t COMPREPLY < <(compgen -W "$(find "${DYNAMIC_WALLPAPERS_ROOT:-$HOME/.dotfiles/lib/wallpapers}" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null)" -- "$cur")
+    return 0
+    ;;
+  --shuffle-mode)
+    mapfile -t COMPREPLY < <(compgen -W "random fixed" -- "$cur")
+    return 0
+    ;;
+  --image)
+    mapfile -t COMPREPLY < <(compgen -f -- "$cur")
     return 0
     ;;
   -l | --log)

--- a/pkgs/dynamic-wallpaper/completions/dynamic-wallpaper.fish
+++ b/pkgs/dynamic-wallpaper/completions/dynamic-wallpaper.fish
@@ -42,5 +42,7 @@ complete -c dynamic-wallpaper -l auto-light -d 'Use the lightest wallpaper when 
 complete -c dynamic-wallpaper -l start -r -d 'Start time for the cycle (HH:MM)' -a '(__dynamic_wallpaper_times)' -f
 complete -c dynamic-wallpaper -l end -r -d 'End time for the cycle (HH:MM)' -a '(__dynamic_wallpaper_times)' -f
 complete -c dynamic-wallpaper -l time -r -d 'Use fake current time (HH:MM)' -a '(__dynamic_wallpaper_times)' -f
+complete -c dynamic-wallpaper -l shuffle-mode -r -d 'Shuffle behavior for shuffle_ groups' -a 'random fixed' -f
+complete -c dynamic-wallpaper -l image -r -d 'Image when --shuffle-mode fixed' -a '(__fish_complete_files)'
 complete -c dynamic-wallpaper -s l -l log -r -d 'Write log output to FILE' -a '(__fish_complete_files)'
 complete -c dynamic-wallpaper -s h -l help -d 'Show help text'

--- a/pkgs/dynamic-wallpaper/update-wallpapers.sh
+++ b/pkgs/dynamic-wallpaper/update-wallpapers.sh
@@ -31,6 +31,8 @@ mapfile -t groups < <(find "$base" -mindepth 1 -maxdepth 1 -type d -printf '%f\n
   echo "> Images in groups need to be named \`<group_name>-n.<file_extenstion>\` in order"
   echo "> to work in a time-based manner. The appropriate wallpaper for the current time"
   echo "> will be selected by its n-index."
+  echo "> Folders prefixed with \`shuffle_\` are treated as non-time-based wallpaper pools"
+  echo "> and can be used with random or fixed image selection via module options."
   echo
   echo "## Packaging"
   echo "Use 'scripts/package_wallpapers.sh' to create zip archives and accompanying"
@@ -69,6 +71,8 @@ mapfile -t groups < <(find "$base" -mindepth 1 -maxdepth 1 -type d -printf '%f\n
   echo "complete -c dynamic-wallpaper -l start -r -d 'Start time for the cycle (HH:MM)' -a '(__dynamic_wallpaper_times)' -f"
   echo "complete -c dynamic-wallpaper -l end -r -d 'End time for the cycle (HH:MM)' -a '(__dynamic_wallpaper_times)' -f"
   echo "complete -c dynamic-wallpaper -l time -r -d 'Use fake current time (HH:MM)' -a '(__dynamic_wallpaper_times)' -f"
+  echo "complete -c dynamic-wallpaper -l shuffle-mode -r -d 'Shuffle behavior for shuffle_ groups' -a 'random fixed' -f"
+  echo "complete -c dynamic-wallpaper -l image -r -d 'Image when --shuffle-mode fixed' -a '(__fish_complete_files)'"
   echo "complete -c dynamic-wallpaper -s l -l log -r -d 'Write log output to FILE' -a '(__fish_complete_files)'"
   echo "complete -c dynamic-wallpaper -s h -l help -d 'Show help text'"
 } >"$completion"


### PR DESCRIPTION
### Motivation
- Add support for non-time-based wallpaper folders prefixed with `shuffle_` so users can treat those folders as pools to be shuffled or pin a single image instead of applying time-slot transitions.
- Expose configuration from the Home Manager module so `shuffle` behavior can be controlled via `dynamic-wallpaper.shuffleMode` and an optional `image` setting.

### Description
- Implemented detection of folders whose basename matches `shuffle_*` and short-circuited the time-based schedule in `pkgs/dynamic-wallpaper/dynamic-wallpaper.sh` to support `random` and `fixed` modes selected via `--shuffle-mode` / `DYNAMIC_WALLPAPER_SHUFFLE_MODE` and `--image` / `DYNAMIC_WALLPAPER_IMAGE`.
- Added filesystem resolution for `fixed` mode (accepts full path, filename in the folder, or stem with common extensions) and preserved existing behavior for symlink `current` mirrors and the visible cache before calling `swww`.
- Added `shuffleMode` and `image` options to the Nix module (`modules/dynamic-wallpaper/default.nix`) and wired them into `home.sessionVariables` and the `systemd.user.services.dynamic-wallpaper` environment so the service and timer receive the settings.
- Updated completions (bash/zsh/fish) and the `update-wallpapers.sh` README/completion generator to advertise and support the new flags and document `shuffle_` folders.

### Testing
- Ran syntax checks: `bash -n pkgs/dynamic-wallpaper/dynamic-wallpaper.sh`, `bash -n pkgs/dynamic-wallpaper/update-wallpapers.sh`, and `bash -n pkgs/dynamic-wallpaper/completions/dynamic-wallpaper.bash`, which all returned clean (no syntax errors).
- Performed functional smoke tests with a temporary wallpapers root and a mocked `swww` binary that exercised `random` mode and `fixed` mode (selecting by stem), and verified the script selected and mirrored expected images and invoked `swww` as expected.
- Verified that existing time-based selection still works by running the script against a non-`shuffle_` folder with a fake time; this succeeded in the smoke test.
- Attempting to run the full `pkgs/dynamic-wallpaper/update-wallpapers.sh` in this environment failed previously because the local wallpapers tree used by the generator lacks real image files (the generator assumes at least one image per group), so README generation cannot be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f1a3f4fc832c87016adaa774d824)